### PR TITLE
Add solve() to headless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,8 @@ You can pass several arguments to the command line, including some flags which a
 |`--o`, `--output=[meshname]_w.obj`| File to save winding number function to, consisting of the mesh along with homogeneous texture coordinates. |
 |`--r`, `--approximateResidual`| Use reduced-size linear program to approximate the residual function, instead of solving a more expensive LP. Off by default. |
 |`--V`, `--verbose`| Verbose output. |
+|`--h`, `--headless`| Don't use the GUI, and automatically solve for & export the final winding number function. The GUI will be shown by default.|
 |`--help`| Display help |
-
-<!-- |`--h`, `--headless`| Don't use the GUI. The GUI will be shown by default.| -->
 <!-- TODO: Expose all parameters -->
 
 ## File formats

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -825,6 +825,7 @@ int main(int argc, char** argv) {
 
     // Load mesh
     MESH_FILEPATH = args::get(inputFilename);
+    MESHROOT = polyscope::guessNiceNameFromPath(MESH_FILEPATH);
     DATA_DIR = getHomeDirectory(MESH_FILEPATH); // extract home directory
     std::tie(mesh, geometry) = readSurfaceMesh(MESH_FILEPATH);
     // Read line objects, if they exist in mesh file.
@@ -837,6 +838,8 @@ int main(int argc, char** argv) {
     }
     if (outputFilename) {
         OUTPUT_FILENAME = args::get(outputFilename);
+    } else {
+        OUTPUT_FILENAME = DATA_DIR + MESHROOT + "_w.obj";
     }
     // Read flags.
     if (approximateResidual) {
@@ -845,7 +848,9 @@ int main(int argc, char** argv) {
     if (headless) {
         USING_GUI = false;
     }
-    MESHROOT = polyscope::guessNiceNameFromPath(MESH_FILEPATH);
+    if (verbose) {
+        VERBOSE = true;
+    }
 
     // Initialize solver.
     SWNSolver = std::unique_ptr<SurfaceWindingNumbersSolver>(new SurfaceWindingNumbersSolver(*geometry));
@@ -882,9 +887,7 @@ int main(int argc, char** argv) {
         displayCurves(getGeom(), getCurveHalfedges(), CURVE_NODES, CURVE_EDGES, DUAL_CHAIN);
 
         polyscope::show();
-    }
-    else
-    {
+    } else {
         solve();
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -883,6 +883,10 @@ int main(int argc, char** argv) {
 
         polyscope::show();
     }
+    else
+    {
+        solve();
+    }
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
I'm not sure I understood how to use "headless mode", is a `solve()` missing here? If not, I get no output 